### PR TITLE
Add default _PitayaGetCFBundleVersion method implementation to fix An…

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -532,8 +532,11 @@ namespace Pitaya
         [DllImport(LibName, EntryPoint = "pc_lib_clear_pinned_public_keys")]
         private static extern void NativeClearPinnedPublicKeys();
 
+#if UNITY_IPHONE && !UNITY_EDITOR
         [DllImport("__Internal")]
         private static extern string _PitayaGetCFBundleVersion();
-
+#else
+        private static string _PitayaGetCFBundleVersion() { return "1"; }
+#endif
     }
 }


### PR DESCRIPTION
Add default _PitayaGetCFBundleVersion method implementation to fix Android IL2CPP compilation error (undefined function)