### PR TITLE
Fixed Unity Editor required to be restarted to update game version

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -116,33 +116,24 @@ namespace Pitaya
 
         private static string Platform()
         {
-            string platform;
             switch (Application.platform)
             {
                 case RuntimePlatform.Android:
-                    platform = "android";
-                    break;
+                    return "android";
                 case RuntimePlatform.LinuxEditor:
                 case RuntimePlatform.LinuxPlayer:
-                    platform = "linux";
-                    break;
+                    return "linux";
                 case RuntimePlatform.WindowsEditor:
                 case RuntimePlatform.WindowsPlayer:
-                    platform = "windows";
-                    break;
+                    return "windows";
                 case RuntimePlatform.IPhonePlayer:
-                    platform = "ios";
-                    break;
+                    return "ios";
                 case RuntimePlatform.OSXEditor:
                 case RuntimePlatform.OSXPlayer:
-                    platform = "mac";
-                    break;
+                    return "mac";
                 default:
-                    platform = Application.platform.ToString();
-                    break;
+                    return Application.platform.ToString();
             }
-
-            return platform;
         }
         
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]

--- a/unity/PitayaExample/LibPitaya.nuspec
+++ b/unity/PitayaExample/LibPitaya.nuspec
@@ -2,13 +2,13 @@
 <package>
   <metadata>
     <id>LibPitaya</id>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <authors>guthyerrz</authors>
     <owners>guthyerrz</owners>
     <projectUrl>https://github.com/topfreegames/libpitaya</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>C# client for the pitaya server</description>
-    <releaseNotes>Fix connection timeout not being passed on the contructor</releaseNotes>
+    <releaseNotes>Fixed Unity Editor required to be closed and reopened to update game version</releaseNotes>
     <licenseUrl>https://github.com/topfreegames/libpitaya/blob/master/LICENSE</licenseUrl>
     <copyright>Copyright (c) 2018 TFG Co, NetEase Inc. and other pomelo contributors</copyright>
     <tags>pitaya libpitaya</tags>


### PR DESCRIPTION
Currently, if we change the game version in Unity Editor, we need to restart Unity to make these changes available. The same probably happens for platform changes (didn't test it).

This bug prevents us from easily switching stacks during development (we usually work on two versions simultaneously, besides live version). It has caused many people to spend time debugging server issues before they discover it :/ 

Best,
Renato