### PR TITLE
Add Unity Editor assembly definition file.

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef
+++ b/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Pitaya.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef.meta
+++ b/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6722a5e00a1264234a2bad26aa55110a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull requests adds an `.asmdef` file for the Editor folder in order to easily allow use of `.asmdef` files within a parent project.