### PR TITLE
Add support for Unity 2019.3 (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit testing (not only integration tests)
 - Better support for languages other than C#
 
+## [4.0.0] - 2020-04-04
+### Fixed
+- Fix AndroidJavaClass errors for Pitaya.dll in Android
+
+### Added
+- Add UnityEngine.AndroidJNIModule dependency (this breaks compatibility with Unity versions older than 2019.3)
+
 ## [3.0.4] - 2020-02-04
 ### Fixed
 - c#: Fixed Unity Editor required to be closed and reopened to update game version

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Libpitaya is currently under development and is not yet ready for production use. We are working on tests and better documentation and we'll update the project as soon as possible.
 
+Libpitaya C# binding for 4.0.0 and above require Unity 2019.3 to work.
+
 # Libpitaya
 
 Libpitaya is a SDK for building clients for projects using the pitaya game server framework and is built on top of [libpomelo2](https://github.com/NetEase/libpomelo2)

--- a/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef
+++ b/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Pitaya.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef.meta
+++ b/unity/PitayaExample/Assets/Pitaya/Editor/Pitaya.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6722a5e00a1264234a2bad26aa55110a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PitayaExample/Assets/Pitaya/Editor/PitayaXcodeProjectUpdater.cs
+++ b/unity/PitayaExample/Assets/Pitaya/Editor/PitayaXcodeProjectUpdater.cs
@@ -16,10 +16,10 @@ public class PitayaBuildPostprocessor
 			PBXProject proj = new PBXProject();
 			proj.ReadFromString(File.ReadAllText(projPath));
 
-			string target = proj.TargetGuidByName("Unity-iPhone");
+			string targetGuid = proj.GetUnityFrameworkTargetGuid();
 
 			// Pitaya should be linked with zlib when on iOS.
-			proj.AddBuildProperty(target, "OTHER_LDFLAGS", "-lz");
+			proj.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-lz");
 
 			File.WriteAllText(projPath, proj.WriteToString());
 		}

--- a/unity/PitayaExample/Makefile
+++ b/unity/PitayaExample/Makefile
@@ -31,7 +31,7 @@ pack: build-all
 	@nuget pack LibPitaya.nuspec -OutputDirectory NugetOutput
 
 # UNITY_PATH should contain the path to the Unity.app folder
-UNITY_PATH=
+UNITY_PATH=/Applications/Unity/Hub/Editor/2019.3.7f1/Unity.app
 
 test:
 	${UNITY_PATH}/Contents/MacOS/Unity -runTests -projectPath $(shell pwd) -testResults $(shell pwd)/test-results-playmode.xml -testPlatform playmode -batchmode -nographics -logFile

--- a/unity/PitayaExample/NugetOutput/Unity/Editor/PitayaXcodeProjectUpdater.cs
+++ b/unity/PitayaExample/NugetOutput/Unity/Editor/PitayaXcodeProjectUpdater.cs
@@ -16,10 +16,10 @@ public class PitayaBuildPostprocessor
 			PBXProject proj = new PBXProject();
 			proj.ReadFromString(File.ReadAllText(projPath));
 
-			string target = proj.TargetGuidByName("Unity-iPhone");
+			string targetGuid = proj.GetUnityFrameworkTargetGuid();
 
 			// Pitaya should be linked with zlib when on iOS.
-			proj.AddBuildProperty(target, "OTHER_LDFLAGS", "-lz");
+			proj.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-lz");
 
 			File.WriteAllText(projPath, proj.WriteToString());
 		}

--- a/unity/PitayaExample/Pitaya-Build-Template.csproj
+++ b/unity/PitayaExample/Pitaya-Build-Template.csproj
@@ -50,7 +50,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">
-      <HintPath>/Applications/Unity201842f1/Unity.app/Contents/Managed/UnityEngine/UnityEngine.dll</HintPath>
+      <HintPath>UNITY_PATH/Contents/Managed/UnityEngine/UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor">
+      <HintPath>UNITY_PATH/Contents/Managed/UnityEditor.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -66,6 +69,9 @@
     <Compile Include="Assets\Pitaya\SimpleJson.cs" />
     <Compile Include="Assets\Pitaya\TypeSubscriber.cs" />
     <None Include="Assets\Pitaya\Pitaya.asmdef" />
+    <Reference Include="UnityEngine.AndroidJNIModule">
+      <HintPath>UNITY_PATH/Contents/Managed/UnityEngine/UnityEngine.AndroidJNIModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>UNITY_PATH/Contents/Managed/UnityEngine/UnityEngine.CoreModule.dll</HintPath>
     </Reference>


### PR DESCRIPTION
This PR fixes all errors after migrating to Unity 2019.3:
- Missing `UnityEngine.AndroidJNIModule` reference
- `AndroidJavaClass` runtime error
- `GetUnityFrameworkTargetGuid()` API change
- Missing `Pitaya.Editor.asmdef` (don't remember if this was actually breaking the build)

Considering that it required to change `UnityEngine.dll` and add `UnityEngine.AndroidJNIModule.dll` references, I'm treating this a a breaking change and not handling retrocompatibility in the API change mentioned above. I've also added a version 4.0.0 in the changelog.