### PR TITLE
Fix Unity 2019.3 crash in Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit testing (not only integration tests)
 - Better support for languages other than C#
 
+## [4.0.1] - 2020-06-03
+### Fixed
+- Fix crash in Unity 2019.3 when running in Linux
+
 ## [4.0.0] - 2020-04-04
+**This version breaks compatibility with Unity 2018.4 or older**
 ### Fixed
 - Fix AndroidJavaClass errors for Pitaya.dll in Android
 

--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -61,6 +61,7 @@ namespace Pitaya
         private static readonly Dictionary<IntPtr, WeakReference> Listeners = new Dictionary<IntPtr, WeakReference>();
         private static readonly Dictionary<IntPtr, int> EventHandlersIds = new Dictionary<IntPtr, int>();
         private static PitayaLogLevel _currentLogLevel = PitayaLogLevel.Disable;
+        private static bool IsNativeLibInitialized;
 
         private static void DLog(object data)
         {
@@ -79,7 +80,6 @@ namespace Pitaya
             NativeErrorCallback = OnError;
             
             SetLogFunction(LogFunction);
-            NativeLibInit((int) _currentLogLevel, null, null, OnAssert, Platform(), BuildNumber(), Application.version);
         }
 
         private static void SetLogFunction(NativeLogFunction fn)
@@ -147,6 +147,12 @@ namespace Pitaya
         
         public static IntPtr CreateClient(bool enableTls, bool enablePolling, bool enableReconnect, int connTimeout, IPitayaListener listener)
         {
+            if (!IsNativeLibInitialized)
+            {
+                NativeLibInit((int) _currentLogLevel, null, null, OnAssert, Platform(), BuildNumber(), Application.version);
+                IsNativeLibInitialized = true;
+            }
+            
             var client = NativeCreate(enableTls, enablePolling, enableReconnect, connTimeout);
             if (client == IntPtr.Zero)
             {

--- a/unity/PitayaExample/LibPitaya.nuspec
+++ b/unity/PitayaExample/LibPitaya.nuspec
@@ -8,7 +8,9 @@
     <projectUrl>https://github.com/topfreegames/libpitaya</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>C# client for the pitaya server</description>
-    <releaseNotes>Fix compatibility with Unity 2019.3</releaseNotes>
+    <releaseNotes>Fix crash in Unity 2019.3 when running in Linux
+Fix compatibility with Unity 2019.3
+This version breaks compatibility with Unity 2018.4 or older</releaseNotes>
     <licenseUrl>https://github.com/topfreegames/libpitaya/blob/master/LICENSE</licenseUrl>
     <copyright>Copyright (c) 2018 TFG Co, NetEase Inc. and other pomelo contributors</copyright>
     <tags>pitaya libpitaya</tags>

--- a/unity/PitayaExample/LibPitaya.nuspec
+++ b/unity/PitayaExample/LibPitaya.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>LibPitaya</id>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <authors>guthyerrz</authors>
     <owners>guthyerrz</owners>
     <projectUrl>https://github.com/topfreegames/libpitaya</projectUrl>


### PR DESCRIPTION
This pull request moves the native library initialization away from the static C# constructor of `PitayaBinding` to avoid a crash in Linux when running an application built with Unity 2019.3.

**The crash still happens anyway if you try to call the initialization later. This is just a workaround to not crash applications that include the library but doesn't use it.**

This pull requests also updates the changelog and `.nuspec` release notes.