### PR TITLE
Fix Unity Editor crash

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -141,7 +141,9 @@ namespace Pitaya
         {
             if (Application.isEditor)
             {
+                NativeLibInit((int) _currentLogLevel, null, null, OnAssert, Platform(), BuildNumber(), Application.version);
                 NativeLibUpdateClientInfo(Platform(), BuildNumber(), Application.version);
+                IsNativeLibInitialized = true;
             }
         }
         


### PR DESCRIPTION
This merge request fixes a play mode Unity Editor crash caused by `NativeLibUpdateClientInfo()` being called before `NativeLibInit()`.