### PR TITLE
Fix crash in Unity 2019.3 when running in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit testing (not only integration tests)
 - Better support for languages other than C#
 
+## [4.1.1] - Unreleased
+### Fixed
+- Fix crash in Unity 2019.3 when running in Android
+
 ## [4.1.0] - 2020-06-03
 ### Added
 - ClearAllCallbacks method on PitayaClient class

--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -80,6 +80,9 @@ namespace Pitaya
             NativeErrorCallback = OnError;
             
             SetLogFunction(LogFunction);
+#if UNITY_ANDROID
+            InitializeNativeLib();
+#endif
         }
 
         private static void SetLogFunction(NativeLogFunction fn)
@@ -141,19 +144,22 @@ namespace Pitaya
         {
             if (Application.isEditor)
             {
-                NativeLibInit((int) _currentLogLevel, null, null, OnAssert, Platform(), BuildNumber(), Application.version);
+#if !UNITY_ANDROID
+            InitializeNativeLib();
+#endif
                 NativeLibUpdateClientInfo(Platform(), BuildNumber(), Application.version);
-                IsNativeLibInitialized = true;
             }
+        }
+
+        private static void InitializeNativeLib()
+        {
+            NativeLibInit((int)_currentLogLevel, null, null, OnAssert, Platform(), BuildNumber(), Application.version);
+            IsNativeLibInitialized = true;
         }
         
         public static IntPtr CreateClient(bool enableTls, bool enablePolling, bool enableReconnect, int connTimeout, IPitayaListener listener)
         {
-            if (!IsNativeLibInitialized)
-            {
-                NativeLibInit((int) _currentLogLevel, null, null, OnAssert, Platform(), BuildNumber(), Application.version);
-                IsNativeLibInitialized = true;
-            }
+            if (!IsNativeLibInitialized) InitializeNativeLib();
             
             var client = NativeCreate(enableTls, enablePolling, enableReconnect, connTimeout);
             if (client == IntPtr.Zero)

--- a/unity/PitayaExample/LibPitaya.nuspec
+++ b/unity/PitayaExample/LibPitaya.nuspec
@@ -2,16 +2,14 @@
 <package>
   <metadata>
     <id>LibPitaya</id>
-    <version>4.1.0</version>
+    <version>4.1.1-alpha.1</version>
     <authors>guthyerrz</authors>
     <owners>guthyerrz</owners>
     <projectUrl>https://github.com/topfreegames/libpitaya</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>C# client for the pitaya server</description>
-    <releaseNotes>Add ClearAllCallbacks method on PitayaClient class
-Fix crash in Unity 2019.3 when running in Linux
-Fix compatibility with Unity 2019.3
-This version breaks compatibility with Unity 2018.4 or older</releaseNotes>
+    <releaseNotes>Fix crash in Unity 2019.3 when running in Android
+* This version isn't compatible with Unity 2018.4 or older</releaseNotes>
     <licenseUrl>https://github.com/topfreegames/libpitaya/blob/master/LICENSE</licenseUrl>
     <copyright>Copyright (c) 2018 TFG Co, NetEase Inc. and other pomelo contributors</copyright>
     <tags>pitaya libpitaya</tags>


### PR DESCRIPTION
This pull request fixes a crash in Android caused by #29 as a side effect. What it does is a workaround, reverting the change done by this other PR only for Android.

The crash is reported [here](https://github.com/topfreegames/libpitaya/commit/14970588dbbe7dbfb60964a604dd548c698d4af9#commitcomment-39901878).

It seems related to libuv and happens on arm64 devices only, so it might be interesting to update it to a more recent version (check releases [here](https://github.com/libuv/libuv/releases)).