### PR TITLE
Round trip time measurement

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaMetrics.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaMetrics.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Pitaya
+{
+    public class PitayaMetrics
+    {
+        private int[] _rttSamples;
+        private int _validPings;
+        public PitayaMetrics()
+        {
+            _rttSamples = new int[3];
+            _validPings = 0;
+        }
+
+        public void PingReceived(int ping)
+        {
+            if (ping < 0) return;
+            if (_validPings < 3) _validPings++;
+            _rttSamples[2] = _rttSamples[1];
+            _rttSamples[1] = _rttSamples[0];
+            _rttSamples[0] = ping;
+
+        }
+
+        public int GetRTT()
+        {
+            if (_validPings == 0) return -1;
+            if (_validPings == 1) return _rttSamples[0];
+            else if (_validPings == 2) {
+                return (_rttSamples[1] + _rttSamples[0]) / 2;
+            }
+            int highest = Math.Max(_rttSamples[2], _rttSamples[1]);
+            highest = Math.Max(highest, _rttSamples[0]);
+            return (_rttSamples[2] + _rttSamples[1] + _rttSamples[0] - highest) / 2;
+        }
+
+    }
+
+
+
+}

--- a/unity/PitayaExample/Assets/Pitaya/PitayaMetrics.cs.meta
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97f8f3d7d57ee4965826853d5500324a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi, I just added a way to measure the connection RTT from the client-side but I'm not sure it's the best way to do that. 
Btw, to compute the current RTT I used the same approach of [this](https://github.com/ValveSoftware/GameNetworkingSockets/blob/master/src/steamnetworkingsockets/steamnetworkingsockets_stats.cpp#L93).