### PR TITLE
Add IPitayaQueueDispatcher, refactor MainQueueDispatcher and remove static calls from PitayaBinding

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/IPitayaClient.cs.meta
+++ b/unity/PitayaExample/Assets/Pitaya/IPitayaClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 195e191c39f784901921932f3a71c56e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PitayaExample/Assets/Pitaya/IPitayaQueueDispatcher.cs
+++ b/unity/PitayaExample/Assets/Pitaya/IPitayaQueueDispatcher.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Pitaya
+{
+    public interface IPitayaQueueDispatcher
+    {
+        void Dispatch(Action action);
+    }
+
+    public class NullPitayaQueueDispatcher : IPitayaQueueDispatcher
+    {
+        public void Dispatch(Action action)
+        {
+            action();
+        }
+    }
+}

--- a/unity/PitayaExample/Assets/Pitaya/IPitayaQueueDispatcher.cs.meta
+++ b/unity/PitayaExample/Assets/Pitaya/IPitayaQueueDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2982b747a68b442889ec8e181ed62fda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -62,6 +62,8 @@ namespace Pitaya
         private static readonly Dictionary<IntPtr, int> EventHandlersIds = new Dictionary<IntPtr, int>();
         private static PitayaLogLevel _currentLogLevel = PitayaLogLevel.Disable;
         private static bool IsNativeLibInitialized;
+        
+        public static IPitayaQueueDispatcher QueueDispatcher { get; set; } = new NullPitayaQueueDispatcher();
 
         private static void DLog(object data)
         {
@@ -405,7 +407,7 @@ namespace Pitaya
                 error = new PitayaError(code, "Internal Pitaya error");
             }
 
-            MainQueueDispatcher.Dispatch(() =>
+            QueueDispatcher.Dispatch(() =>
             {
                 WeakReference reference;
                 if (!Listeners.TryGetValue(client, out reference) || !reference.IsAlive) return;
@@ -422,7 +424,7 @@ namespace Pitaya
             var rawData = new byte[buffer.Len];
             Marshal.Copy(buffer.Data, rawData, 0, (int)buffer.Len);
 
-            MainQueueDispatcher.Dispatch(() =>
+            QueueDispatcher.Dispatch(() =>
             {
                 WeakReference reference;
                 if (!Listeners.TryGetValue(client, out reference) || !reference.IsAlive) return;
@@ -456,7 +458,7 @@ namespace Pitaya
             }
 
             var listener = reference.Target as IPitayaListener;
-            MainQueueDispatcher.Dispatch(() =>
+            QueueDispatcher.Dispatch(() =>
             {
                 if (listener != null) listener.OnUserDefinedPush(route, rawData);
             });
@@ -481,7 +483,7 @@ namespace Pitaya
 
             var listener = reference.Target as IPitayaListener;
 
-            MainQueueDispatcher.Dispatch(() =>
+            QueueDispatcher.Dispatch(() =>
             {
                 switch (ev)
                 {

--- a/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
@@ -20,23 +20,14 @@ namespace Pitaya
         private TypeSubscriber<uint> _typeRequestSubscriber;
         private TypeSubscriber<string> _typePushSubscriber;
 
-        public PitayaClient()
+        public PitayaClient() : this(false) {}
+        public PitayaClient(int connectionTimeout) : this(false, null, connectionTimeout: connectionTimeout) {}
+        public PitayaClient(string certificateName = null) : this(false, certificateName: certificateName) {}
+        
+        public PitayaClient(bool enableReconnect = false, string certificateName = null, int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT, IPitayaQueueDispatcher queueDispatcher = null)
         {
-            Init(null, false, false, false, DEFAULT_CONNECTION_TIMEOUT);
-        }
-
-        public PitayaClient(int connectionTimeout)
-        {
-            Init(null, false, false, false, connectionTimeout);
-        }
-
-        public PitayaClient(string certificateName = null)
-        {
-            Init(certificateName, certificateName != null, false, false, DEFAULT_CONNECTION_TIMEOUT);
-        }
-
-        public PitayaClient(bool enableReconnect = false, string certificateName = null, int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT)
-        {
+            if (queueDispatcher == null) queueDispatcher = MainQueueDispatcher.Create();
+            PitayaBinding.QueueDispatcher = queueDispatcher;
             Init(certificateName, certificateName != null, false, enableReconnect, connectionTimeout);
         }
 

--- a/unity/PitayaExample/Pitaya-Build-Template.csproj
+++ b/unity/PitayaExample/Pitaya-Build-Template.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Assets\Pitaya\EventManager.cs" />
     <Compile Include="Assets\Pitaya\JsonSerializer.cs" />
     <Compile Include="Assets\Pitaya\MainQueueDispatcher.cs" />
+    <Compile Include="Assets\Pitaya\IPitayaQueueDispatcher.cs" />
     <Compile Include="Assets\Pitaya\PitayaBinding.cs" />
     <Compile Include="Assets\Pitaya\PitayaClient.cs" />
     <Compile Include="Assets\Pitaya\IPitayaClient.cs" />


### PR DESCRIPTION
This PR does the following:
* Add `IPitayaQueueDispatcher` interface
* Remove unused methods from `MainQueueDispatcher`
* Refactor `MainQueueDispatcher` to be used as an instance (instead of static)
* Remove static calls to `MainQueueDispatcher` from `PitayaBinding`, replace by an `IPitayaQueueDispatcher` instance
* Add a default implementation of `IPitayaQueueDispatcher` to `PitayaBinding`
* Add a default instantiation of `MainQueueDispatcher` in `PitayaClient` constructor to maintain retrocompatibility

All these changes came from the need of running application integration tests in Unity Edit Mode. Having Pitaya force Play Mode tests isn't great.

In the future, I think we can completely remove this MainQueueDispatcher that depends on Unity's `Coroutine` and `MonoBehaviour`. We'll be one step closer of having Pitaya independent of Unity.