### PR TITLE
Fix crash caused by modified collection during enumeration

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/EventManager.cs
+++ b/unity/PitayaExample/Assets/Pitaya/EventManager.cs
@@ -38,7 +38,6 @@ namespace Pitaya
             ClearCallbacks(id);
             
             if (foundAction) action.Invoke(data);
-
         }
 
         public void InvokeErrorCallBack(uint id, PitayaError error)
@@ -49,8 +48,6 @@ namespace Pitaya
             ClearCallbacks(id);
             
             if (foundAction) action.Invoke(error);
-
-            
         }
 
         private void ClearCallbacks(uint id)
@@ -64,7 +61,6 @@ namespace Pitaya
             _callBackMap.Clear();
             _errorCallBackMap.Clear();
         }
-
 
         // Adds the event to eventMap by name.
         public void AddOnRouteEvent(string routeName, Action<byte[]> callback)
@@ -89,7 +85,6 @@ namespace Pitaya
         {
             _eventMap.Clear();
         }
-
 
         /// <summary>
         /// If the event exists,invoke the event when server return messge.
@@ -116,8 +111,8 @@ namespace Pitaya
         private void Dispose(bool disposing)
         {
             var errorCallBackMap = new Dictionary<uint, Action<PitayaError>>(_errorCallBackMap);
-			foreach (var callback in errorCallBackMap)
-				callback.Value.Invoke(new PitayaError(PitayaConstants.PitayaInternalError, "pitaya exited"));
+            foreach (var callback in errorCallBackMap)
+                callback.Value.Invoke(new PitayaError(PitayaConstants.PitayaInternalError, "pitaya exited"));
 
             _callBackMap.Clear();
             _eventMap.Clear();

--- a/unity/PitayaExample/Assets/Pitaya/EventManager.cs
+++ b/unity/PitayaExample/Assets/Pitaya/EventManager.cs
@@ -115,7 +115,8 @@ namespace Pitaya
         // ReSharper disable once UnusedParameter.Local
         private void Dispose(bool disposing)
         {
-			foreach (var callback in _errorCallBackMap)
+            var errorCallBackMap = new Dictionary<uint, Action<PitayaError>>(_errorCallBackMap);
+			foreach (var callback in errorCallBackMap)
 				callback.Value.Invoke(new PitayaError(PitayaConstants.PitayaInternalError, "pitaya exited"));
 
             _callBackMap.Clear();


### PR DESCRIPTION
This PR fixes a crash caused by modified collection during enumeration in `EventManager.Dispose()`.

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
			--TearDown  at System.Collections.Generic.Dictionary`2+Enumerator[TKey,TValue].MoveNext () [0x00016] in <fb001e01371b4adca20013e0ac763896>:0
               at Pitaya.EventManager.Dispose (System.Boolean disposing) [0x00032] in <f6e36b93844f4e5184ee737c3ef0ed7a>:0
               at Pitaya.EventManager.Dispose () [0x00000] in <f6e36b93844f4e5184ee737c3ef0ed7a>:0
               at Pitaya.PitayaClient.Dispose () [0x0002b] in <f6e36b93844f4e5184ee737c3ef0ed7a>:0
[rest of the stack trace]
```

I reproduced it when running integration tests in Edit Mode in Unity 2019.4, during `TearDown()`.