### PR TITLE
Rename DefaultSerializerFactory to SerializerFactory and expose JSON serialization settings

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/ISerializerFactory.cs
+++ b/unity/PitayaExample/Assets/Pitaya/ISerializerFactory.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Pitaya
 {
     public interface ISerializerFactory
@@ -6,11 +8,20 @@ namespace Pitaya
         IPitayaSerializer CreateProtobufSerializer(ProtobufSerializer.SerializationFormat format);
     }
 
-    public class DefaultSerializerFactory : ISerializerFactory
+    public class SerializerFactory : ISerializerFactory
     {
+        private readonly JsonSerializerSettings _settings;
+
+        public SerializerFactory() : this(new JsonSerializerSettings()) {}
+        
+        public SerializerFactory(JsonSerializerSettings settings)
+        {
+            _settings = settings;
+        }
+        
         public IPitayaSerializer CreateJsonSerializer()
         {
-            return new JsonSerializer();
+            return new JsonSerializer(_settings);
         }
         
         public IPitayaSerializer CreateProtobufSerializer(ProtobufSerializer.SerializationFormat format)

--- a/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
@@ -28,7 +28,7 @@ namespace Pitaya
         {
             if (queueDispatcher == null) queueDispatcher = MainQueueDispatcher.Create();
             PitayaBinding.QueueDispatcher = queueDispatcher;
-            Init(certificateName, certificateName != null, false, enableReconnect, connectionTimeout, new DefaultSerializerFactory());
+            Init(certificateName, certificateName != null, false, enableReconnect, connectionTimeout, new SerializerFactory());
         }
 
         ~PitayaClient()


### PR DESCRIPTION
This is a quality of life improvement to allow customization of JSON serialization settings without the need of a custom `ISerializerFactory` implementation.