### PR TITLE
Add IPitayaBinding and hide static API to improve testability

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -50,7 +50,53 @@ namespace Pitaya
         void OnUserDefinedPush(string route, byte[] serializedBody);
     }
 
-    public static class PitayaBinding
+    public interface IPitayaBinding
+    {
+        IPitayaQueueDispatcher QueueDispatcher { get; set; }
+        IntPtr CreateClient(bool enableTls, bool enablePolling, bool enableReconnect, int connTimeout, IPitayaListener listener);
+        void Connect(IntPtr client, string host, int port, string handshakeOpts);
+        void Disconnect(IntPtr client);
+        void SetCertificateName(string name);
+        void SetCertificatePath(string path);
+        void Request(IntPtr client, string route, byte[] msg, uint reqtId, int timeout);
+        void Notify(IntPtr client, string route, byte[] msg, int timeout);
+        int Quality(IntPtr client);
+        PitayaClientState State(IntPtr client);
+        void Dispose(IntPtr client);
+        ProtobufSerializer.SerializationFormat ClientSerializer(IntPtr client);
+        void AddPinnedPublicKeyFromCertificateString(string caString);
+        void AddPinnedPublicKeyFromCertificateFile(string name);
+        void SkipKeyPinCheck(bool shouldSkip);
+        void ClearPinnedPublicKeys();
+    }
+
+    public class PitayaBinding : IPitayaBinding
+    {
+        public IPitayaQueueDispatcher QueueDispatcher
+        {
+            get => StaticPitayaBinding.QueueDispatcher;
+            set => StaticPitayaBinding.QueueDispatcher = value;
+        }
+
+        public IntPtr CreateClient(bool enableTls, bool enablePolling, bool enableReconnect, int connTimeout, IPitayaListener listener) { return StaticPitayaBinding.CreateClient(enableTls, enablePolling, enableReconnect, connTimeout, listener); }
+        public void SetLogLevel(PitayaLogLevel logLevel) { StaticPitayaBinding.SetLogLevel(logLevel); }
+        public void Connect(IntPtr client, string host, int port, string handshakeOpts) { StaticPitayaBinding.Connect(client, host, port, handshakeOpts); }
+        public void Disconnect(IntPtr client) { StaticPitayaBinding.Disconnect(client); }
+        public void SetCertificateName(string name) { StaticPitayaBinding.SetCertificateName(name); }
+        public void SetCertificatePath(string path) { StaticPitayaBinding.SetCertificatePath(path); }
+        public void Request(IntPtr client, string route, byte[] msg, uint reqtId, int timeout) { StaticPitayaBinding.Request(client, route, msg, reqtId, timeout); }
+        public void Notify(IntPtr client, string route, byte[] msg, int timeout) { StaticPitayaBinding.Notify(client, route, msg, timeout); }
+        public int Quality(IntPtr client) { return StaticPitayaBinding.Quality(client); }
+        public PitayaClientState State(IntPtr client) { return StaticPitayaBinding.State(client); }
+        public void Dispose(IntPtr client) { StaticPitayaBinding.Dispose(client); }
+        public ProtobufSerializer.SerializationFormat ClientSerializer(IntPtr client) { return StaticPitayaBinding.ClientSerializer(client); }
+        public void AddPinnedPublicKeyFromCertificateString(string caString) { StaticPitayaBinding.AddPinnedPublicKeyFromCertificateString(caString); }
+        public void AddPinnedPublicKeyFromCertificateFile(string name) { StaticPitayaBinding.AddPinnedPublicKeyFromCertificateFile(name); }
+        public void SkipKeyPinCheck(bool shouldSkip) { StaticPitayaBinding.SkipKeyPinCheck(shouldSkip); }
+        public void ClearPinnedPublicKeys() { StaticPitayaBinding.ClearPinnedPublicKeys(); }
+    }
+
+    public static class StaticPitayaBinding
     {
         private static readonly NativeNotifyCallback NativeNotifyCallback;
         private static readonly NativeRequestCallback NativeRequestCallback;
@@ -73,7 +119,7 @@ namespace Pitaya
             }
         }
 
-        static PitayaBinding()
+        static StaticPitayaBinding()
         {
             NativeRequestCallback = OnRequest;
             NativeEventCallback = OnEvent;

--- a/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
@@ -19,15 +19,16 @@ namespace Pitaya
         private bool _disposed;
         private uint _reqUid;
         private Dictionary<uint, Action<string, string>> _requestHandlers;
+        private IPitayaBinding _binding = new PitayaBinding();
         
         public PitayaClient() : this(false) {}
         public PitayaClient(int connectionTimeout) : this(false, null, connectionTimeout: connectionTimeout) {}
         public PitayaClient(string certificateName = null) : this(false, certificateName: certificateName) {}
-        
-        public PitayaClient(bool enableReconnect = false, string certificateName = null, int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT, IPitayaQueueDispatcher queueDispatcher = null)
+        public PitayaClient(bool enableReconnect = false, string certificateName = null, int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT, IPitayaQueueDispatcher queueDispatcher = null, IPitayaBinding binding = null)
         {
+            if (binding != null) _binding = binding;
             if (queueDispatcher == null) queueDispatcher = MainQueueDispatcher.Create();
-            PitayaBinding.QueueDispatcher = queueDispatcher;
+            _binding.QueueDispatcher = queueDispatcher;
             Init(certificateName, certificateName != null, false, enableReconnect, connectionTimeout, new DefaultSerializerFactory());
         }
 
@@ -40,46 +41,46 @@ namespace Pitaya
         {
             SerializerFactory = serializerFactory;
             _eventManager = new EventManager();
-            _client = PitayaBinding.CreateClient(enableTlS, enablePolling, enableReconnect, connTimeout, this);
+            _client = _binding.CreateClient(enableTlS, enablePolling, enableReconnect, connTimeout, this);
 
             if (certificateName != null)
             {
 #if UNITY_EDITOR
                 if (File.Exists(certificateName))
-                    PitayaBinding.SetCertificatePath(certificateName);
+                    _binding.SetCertificatePath(certificateName);
                 else
-                    PitayaBinding.SetCertificateName(certificateName);
+                    _binding.SetCertificateName(certificateName);
 #else
-                PitayaBinding.SetCertificateName(certificateName);
+                _binding.SetCertificateName(certificateName);
 #endif
             }
         }
 
         public static void SetLogLevel(PitayaLogLevel level)
         {
-            PitayaBinding.SetLogLevel(level);
+            StaticPitayaBinding.SetLogLevel(level);
         }
 
         public int Quality
         {
-            get { return PitayaBinding.Quality(_client); }
+            get { return _binding.Quality(_client); }
         }
 
 
         public PitayaClientState State
         {
-            get { return PitayaBinding.State(_client); }
+            get { return _binding.State(_client); }
         }
 
         public void Connect(string host, int port, string handshakeOpts = null)
         {
-            PitayaBinding.Connect(_client, host, port, handshakeOpts);
+            _binding.Connect(_client, host, port, handshakeOpts);
         }
 
         public void Connect(string host, int port, Dictionary<string, string> handshakeOpts)
         {
             var opts = Pitaya.SimpleJson.SimpleJson.SerializeObject(handshakeOpts);
-            PitayaBinding.Connect(_client, host, port, opts);
+            _binding.Connect(_client, host, port, opts);
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Pitaya
         public void Request<TResponse>(string route, object msg, Action<TResponse> action, Action<PitayaError> errorAction, int timeout = -1)
         {
             IPitayaSerializer serializer = SerializerFactory.CreateJsonSerializer();
-            if ((IMessage)msg != null) serializer = SerializerFactory.CreateProtobufSerializer(PitayaBinding.ClientSerializer(_client));
+            if ((IMessage)msg != null) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
             RequestInternal(route, msg, timeout, serializer, action, errorAction);
         }
 
@@ -128,7 +129,7 @@ namespace Pitaya
         /// </summary>
         public void Request<T>(string route, IMessage msg, int timeout, Action<T> action, Action<PitayaError> errorAction)
         {
-            ProtobufSerializer.SerializationFormat format = PitayaBinding.ClientSerializer(_client);
+            ProtobufSerializer.SerializationFormat format = _binding.ClientSerializer(_client);
             RequestInternal(route, msg, timeout, SerializerFactory.CreateProtobufSerializer(format), action, errorAction);
         }
         
@@ -148,7 +149,7 @@ namespace Pitaya
 
             _eventManager.AddCallBack(_reqUid, responseAction, errorAction);
 
-            PitayaBinding.Request(_client, route, serializer.Encode(msg), _reqUid, timeout);
+            _binding.Request(_client, route, serializer.Encode(msg), _reqUid, timeout);
         }
 
         /// <summary>
@@ -164,7 +165,7 @@ namespace Pitaya
         public void Notify(string route, object msg, int timeout = -1)
         {
             IPitayaSerializer serializer = SerializerFactory.CreateJsonSerializer();
-            if ((IMessage)msg != null) serializer = SerializerFactory.CreateProtobufSerializer(PitayaBinding.ClientSerializer(_client));
+            if ((IMessage)msg != null) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
             NotifyInternal(route, msg, serializer, timeout);
         }
 
@@ -173,7 +174,7 @@ namespace Pitaya
         /// </summary>
         public void Notify(string route, int timeout, IMessage msg)
         {
-            ProtobufSerializer.SerializationFormat format = PitayaBinding.ClientSerializer(_client);
+            ProtobufSerializer.SerializationFormat format = _binding.ClientSerializer(_client);
             NotifyInternal(route, msg, SerializerFactory.CreateProtobufSerializer(format), timeout);
         }
 
@@ -191,12 +192,12 @@ namespace Pitaya
         public void Notify(string route, int timeout, string msg)
         {
             byte[] bytes = new LegacyJsonSerializer().Encode(msg);
-            PitayaBinding.Notify(_client, route, bytes, timeout);
+            _binding.Notify(_client, route, bytes, timeout);
         }
         
         private void NotifyInternal(string route, object msg, IPitayaSerializer serializer, int timeout = -1)
         {
-            PitayaBinding.Notify(_client, route, serializer.Encode(msg), timeout);
+            _binding.Notify(_client, route, serializer.Encode(msg), timeout);
         }
 
         /// <summary>
@@ -212,7 +213,7 @@ namespace Pitaya
         public void OnRoute<T>(string route, Action<T> action)
         {
             IPitayaSerializer serializer = SerializerFactory.CreateJsonSerializer();
-            if (typeof(IMessage).IsAssignableFrom(typeof(T))) serializer = SerializerFactory.CreateProtobufSerializer(PitayaBinding.ClientSerializer(_client));
+            if (typeof(IMessage).IsAssignableFrom(typeof(T))) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
 
             OnRouteInternal(route, action, serializer);
         }
@@ -230,7 +231,7 @@ namespace Pitaya
 
         public void Disconnect()
         {
-            PitayaBinding.Disconnect(_client);
+            _binding.Disconnect(_client);
         }
 
         //---------------Pitaya Listener------------------------//
@@ -264,8 +265,8 @@ namespace Pitaya
             if (_eventManager != null) _eventManager.Dispose();
 
             _reqUid = 0;
-            PitayaBinding.Disconnect(_client);
-            PitayaBinding.Dispose(_client);
+            _binding.Disconnect(_client);
+            _binding.Dispose(_client);
 
             _client = IntPtr.Zero;
             _disposed = true;

--- a/unity/PitayaExample/Assets/Tests/AddPublicKeyPinningTest.cs
+++ b/unity/PitayaExample/Assets/Tests/AddPublicKeyPinningTest.cs
@@ -15,9 +15,12 @@ namespace Pitaya.Tests
         private string _caPath;
         private string _corruptCaPath;
 
+        private PitayaBinding _binding;
+
         [SetUp]
         public void Init()
         {
+            _binding = new PitayaBinding();
             _corruptCaPath = "corrupt-ca.crt";
             _caPath = "myCA.pem";
             _serverCertPath = "client-ssl.localhost.crt";
@@ -26,19 +29,19 @@ namespace Pitaya.Tests
         [TearDown]
         public void TearDown()
         {
-            PitayaBinding.ClearPinnedPublicKeys();
+            _binding.ClearPinnedPublicKeys();
         }
 
         [UnityTest]
         public IEnumerator ShouldThrowInCaseOfErrorsWhenAddingKey()
         {
             Assert.Catch<Exception>(() =>
-                PitayaBinding.AddPinnedPublicKeyFromCertificateFile("non-existent-path"));
+                _binding.AddPinnedPublicKeyFromCertificateFile("non-existent-path"));
             Assert.Catch<Exception>(() =>
-                PitayaBinding.AddPinnedPublicKeyFromCertificateFile(_corruptCaPath));
+                _binding.AddPinnedPublicKeyFromCertificateFile(_corruptCaPath));
 
             var certText = File.ReadAllText(Path.Combine(Application.streamingAssetsPath, _corruptCaPath));
-            Assert.Catch<Exception>(() => PitayaBinding.AddPinnedPublicKeyFromCertificateString(certText));
+            Assert.Catch<Exception>(() => _binding.AddPinnedPublicKeyFromCertificateString(certText));
 
             return null;
         }
@@ -46,14 +49,14 @@ namespace Pitaya.Tests
         [UnityTest]
         public IEnumerator ShouldWorkWithCorrectCertificates()
         {
-            Assert.DoesNotThrow(() => PitayaBinding.AddPinnedPublicKeyFromCertificateFile(_caPath));
-            Assert.DoesNotThrow(() => PitayaBinding.AddPinnedPublicKeyFromCertificateFile(_serverCertPath));
+            Assert.DoesNotThrow(() => _binding.AddPinnedPublicKeyFromCertificateFile(_caPath));
+            Assert.DoesNotThrow(() => _binding.AddPinnedPublicKeyFromCertificateFile(_serverCertPath));
 
             var caText = File.ReadAllText(Path.Combine(Application.streamingAssetsPath, _caPath));
             var certText = File.ReadAllText(Path.Combine(Application.streamingAssetsPath, _serverCertPath));
 
-            Assert.DoesNotThrow(() => PitayaBinding.AddPinnedPublicKeyFromCertificateString(caText));
-            Assert.DoesNotThrow(() => PitayaBinding.AddPinnedPublicKeyFromCertificateString(certText));
+            Assert.DoesNotThrow(() => _binding.AddPinnedPublicKeyFromCertificateString(caText));
+            Assert.DoesNotThrow(() => _binding.AddPinnedPublicKeyFromCertificateString(certText));
 
             return null;
         }

--- a/unity/PitayaExample/Assets/Tests/JsonSSLRequestTest.cs
+++ b/unity/PitayaExample/Assets/Tests/JsonSSLRequestTest.cs
@@ -25,9 +25,9 @@ namespace Pitaya.Tests
         [SetUp]
         public void Init()
         {
-            // PitayaBinding.AddPinnedPublicKeyFromCaFile("client-ssl.localhost.crt");
+            // StaticPitayaBinding.AddPinnedPublicKeyFromCaFile("client-ssl.localhost.crt");
             _mainThread = Thread.CurrentThread;
-            PitayaBinding.SkipKeyPinCheck(true);
+            StaticPitayaBinding.SkipKeyPinCheck(true);
 
             _client = new PitayaClient("myCA.pem");
             PitayaClient.SetLogLevel(PitayaLogLevel.Debug);


### PR DESCRIPTION
This MR refactors `PitayaBinding` into `StaticPitayaBinding`, replacing all static calls from `PitayaClient` by an actual instance of `PitayaBinding`, which now implements `IPitayaBinding`.

This refactoring is especially important to allow easier implementation of unit tests for C# validation (through mocks, stubs, etc).