### PR TITLE
Add test case and fix invalid cast exception

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
@@ -104,7 +104,7 @@ namespace Pitaya
         public void Request<TResponse>(string route, object msg, Action<TResponse> action, Action<PitayaError> errorAction, int timeout = -1)
         {
             IPitayaSerializer serializer = SerializerFactory.CreateJsonSerializer();
-            if ((IMessage)msg != null) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
+            if (msg is IMessage) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
             RequestInternal(route, msg, timeout, serializer, action, errorAction);
         }
 
@@ -165,7 +165,7 @@ namespace Pitaya
         public void Notify(string route, object msg, int timeout = -1)
         {
             IPitayaSerializer serializer = SerializerFactory.CreateJsonSerializer();
-            if ((IMessage)msg != null) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
+            if (msg is IMessage) serializer = SerializerFactory.CreateProtobufSerializer(_binding.ClientSerializer(_client));
             NotifyInternal(route, msg, serializer, timeout);
         }
 

--- a/unity/PitayaExample/Assets/Tests/PitayaClientTest.cs
+++ b/unity/PitayaExample/Assets/Tests/PitayaClientTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Pitaya.Tests
+{
+    [TestFixture, Category("unit")]
+    public class PitayaClientTest
+    {
+        public class TestResponse
+        {
+            public string Attr;
+            public List<float> List;
+
+            public override bool Equals(object obj)
+            {
+                var o = obj as TestResponse;
+                if (o == null || obj.GetType() != typeof(TestResponse)) return false;
+                else return o.Attr == Attr && o.List.SequenceEqual(List);
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode() ^ Attr.GetHashCode() ^ List.GetHashCode();
+            }
+        }
+        
+        public class TestRequest {}
+        
+        [Test]
+        public void TestJsonRequestCall()
+        {
+            var route = "route";
+
+            var expectedRes = new TestResponse
+            {
+                Attr = "wololo",
+                List = new List<float> { 14.3f, 11.0f, 65.4f }
+            };
+            
+            var mockBinding = Substitute.For<IPitayaBinding>();
+
+            var res = Newtonsoft.Json.JsonConvert.SerializeObject(expectedRes);
+
+            var client = new PitayaClient(binding: mockBinding, queueDispatcher: new NullPitayaQueueDispatcher());
+            mockBinding.When(x => x.Request(Arg.Any<IntPtr>(), route, Arg.Any<byte[]>(), Arg.Any<uint>(), Arg.Any<int>())).Do(x =>
+            {
+                client.OnRequestResponse(1, Encoding.UTF8.GetBytes(res));
+            });
+            
+            var completionSource = new TaskCompletionSource<(TestResponse, PitayaError)>();
+            client.Request<TestResponse>(route, new TestRequest(), (TestResponse response) =>
+            {
+                completionSource.TrySetResult((response, null));
+            }, (PitayaError error) =>
+            {
+                completionSource.TrySetResult((null, error));
+            });
+            
+            (TestResponse resp, PitayaError err) = completionSource.Task.GetAwaiter().GetResult();
+            Assert.Null(err);
+            Assert.AreEqual(expectedRes, resp);
+        }
+        
+        [Test]
+        public void TestJsonNotifyCall()
+        {
+            var route = "route";
+
+            var expectedRes = new TestResponse
+            {
+                Attr = "wololo",
+                List = new List<float> { 14.3f, 11.0f, 65.4f }
+            };
+            
+            var mockBinding = Substitute.For<IPitayaBinding>();
+
+            var res = Newtonsoft.Json.JsonConvert.SerializeObject(expectedRes);
+
+            var client = new PitayaClient(binding: mockBinding, queueDispatcher: new NullPitayaQueueDispatcher());
+            
+            Assert.DoesNotThrow(() =>
+            {
+                client.Notify(route, new TestResponse()); 
+            });
+        }
+    }
+}

--- a/unity/PitayaExample/Assets/Tests/PitayaClientTest.cs.meta
+++ b/unity/PitayaExample/Assets/Tests/PitayaClientTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 34c3d7eb0f69480b9aaa9ca64973353a
+timeCreated: 1606261988

--- a/unity/PitayaExample/Assets/Tests/Tests.asmdef
+++ b/unity/PitayaExample/Assets/Tests/Tests.asmdef
@@ -15,7 +15,9 @@
     "precompiledReferences": [
         "nunit.framework.dll",
         "Google.Protobuf.dll",
-        "Newtonsoft.Json.dll"
+        "Newtonsoft.Json.dll",
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/unity/PitayaExample/Packages/manifest.json
+++ b/unity/PitayaExample/Packages/manifest.json
@@ -6,5 +6,14 @@
     "com.wildlifestudios.nuget.nsubstitute": "4.2.2",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.unitywebrequestwww": "1.0.0"
-  }
+  },
+  "scopedRegistries": [
+    {
+      "name": "WildlifeStudios",
+      "url": "https://artifactory.tfgco.com/artifactory/api/npm/npm-local",
+      "scopes": [
+        "com.wildlifestudios"
+      ]
+    }
+  ]
 }

--- a/unity/PitayaExample/Packages/packages-lock.json
+++ b/unity/PitayaExample/Packages/packages-lock.json
@@ -1,42 +1,5 @@
 {
   "dependencies": {
-    "com.unity.2d.sprite": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.2d.tilemap": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.ads": {
-      "version": "3.4.7",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.analytics": {
-      "version": "3.3.5",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.collab-proxy": {
-      "version": "1.2.16",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ext.nunit": {
       "version": "1.0.0",
       "depth": 1,
@@ -60,24 +23,8 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.multiplayer-hlapi": {
-      "version": "1.0.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "nuget.mono-cecil": "0.1.6-preview"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.purchasing": {
-      "version": "2.0.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.test-framework": {
-      "version": "1.1.14",
+      "version": "1.1.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -87,49 +34,29 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "2.0.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.timeline": {
-      "version": "1.2.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.ugui": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.ui": "1.0.0"
-      }
-    },
-    "com.unity.xr.legacyinputhelpers": {
-      "version": "2.1.4",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "nuget.mono-cecil": {
-      "version": "0.1.6-preview",
+    "com.wildlifestudios.nuget.castlecore": {
+      "version": "4.4.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
+      "url": "https://artifactory.tfgco.com/artifactory/api/npm/npm-local"
     },
-    "com.unity.modules.ai": {
-      "version": "1.0.0",
+    "com.wildlifestudios.nuget.nsubstitute": {
+      "version": "4.2.2",
       "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
+      "source": "registry",
+      "dependencies": {
+        "com.wildlifestudios.nuget.castlecore": "4.4.1",
+        "com.wildlifestudios.nuget.system.threading.tasks.extensions": "4.4.0"
+      },
+      "url": "https://artifactory.tfgco.com/artifactory/api/npm/npm-local"
+    },
+    "com.wildlifestudios.nuget.system.threading.tasks.extensions": {
+      "version": "4.4.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://artifactory.tfgco.com/artifactory/api/npm/npm-local"
     },
     "com.unity.modules.androidjni": {
       "version": "1.0.0",
@@ -137,155 +64,45 @@
       "source": "builtin",
       "dependencies": {}
     },
-    "com.unity.modules.animation": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
     "com.unity.modules.assetbundle": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
     "com.unity.modules.audio": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
-    "com.unity.modules.cloth": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.physics": "1.0.0"
-      }
-    },
-    "com.unity.modules.director": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.modules.animation": "1.0.0"
-      }
-    },
     "com.unity.modules.imageconversion": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
     "com.unity.modules.imgui": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
     "com.unity.modules.jsonserialize": {
       "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.particlesystem": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.physics": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.physics2d": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.screencapture": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.imageconversion": "1.0.0"
-      }
-    },
-    "com.unity.modules.subsystems": {
-      "version": "1.0.0",
       "depth": 1,
       "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0"
-      }
-    },
-    "com.unity.modules.terrain": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
       "dependencies": {}
-    },
-    "com.unity.modules.terrainphysics": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.terrain": "1.0.0"
-      }
-    },
-    "com.unity.modules.tilemap": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.physics2d": "1.0.0"
-      }
-    },
-    "com.unity.modules.ui": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.uielements": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      }
-    },
-    "com.unity.modules.umbra": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.unityanalytics": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      }
     },
     "com.unity.modules.unitywebrequest": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
     "com.unity.modules.unitywebrequestassetbundle": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.assetbundle": "1.0.0",
@@ -294,20 +111,11 @@
     },
     "com.unity.modules.unitywebrequestaudio": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.unitywebrequest": "1.0.0",
         "com.unity.modules.audio": "1.0.0"
-      }
-    },
-    "com.unity.modules.unitywebrequesttexture": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.modules.imageconversion": "1.0.0"
       }
     },
     "com.unity.modules.unitywebrequestwww": {
@@ -321,50 +129,6 @@
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.assetbundle": "1.0.0",
         "com.unity.modules.imageconversion": "1.0.0"
-      }
-    },
-    "com.unity.modules.vehicles": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.physics": "1.0.0"
-      }
-    },
-    "com.unity.modules.video": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.modules.ui": "1.0.0",
-        "com.unity.modules.unitywebrequest": "1.0.0"
-      }
-    },
-    "com.unity.modules.vr": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.xr": "1.0.0"
-      }
-    },
-    "com.unity.modules.wind": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.xr": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.physics": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.subsystems": "1.0.0"
       }
     }
   }


### PR DESCRIPTION
This MR fixes a `InvalidCastException` when trying to cast the request parameters into `IMessage`.

In order to ensure the fix is working properly, I created a unit test that reproduces the issue consistently.

Additionally, this MR:
* Updates `package-lock.json`
* Adds `NSubstitute` as a project dependency (which is distributed through our private npm registry instead of nuget)

If this last bullet point is an issue, we can add the new third party libraries to git versioning.