### PR TITLE
Fix JSON serialization ignoring JsonSerializerSettings

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/JsonSerializer.cs
+++ b/unity/PitayaExample/Assets/Pitaya/JsonSerializer.cs
@@ -19,7 +19,7 @@ namespace Pitaya
         
         public byte[] Encode(object obj)
         {
-            string json = JsonConvert.SerializeObject(obj);
+            string json = JsonConvert.SerializeObject(obj, _settings);
             return System.Text.Encoding.UTF8.GetBytes(json);
         }
 

--- a/unity/PitayaExample/Assets/Tests/SerializerFactoryTest.cs
+++ b/unity/PitayaExample/Assets/Tests/SerializerFactoryTest.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Pitaya.Tests
+{
+    [TestFixture, Category("unit")]
+    public class SerializerFactoryTest
+    {
+        public struct TestStruct
+        {
+            public string ValueA;
+            public float[] ValueB;
+        }
+        
+        [Test]
+        public void TestCreateJsonSerializer()
+        {
+            var strct = new TestStruct
+            {
+                ValueA = "foo",
+                ValueB = new float[] {23.4f, 12.3f},
+            };
+            
+            var settings = new JsonSerializerSettings();
+            settings.Formatting = Formatting.Indented;
+            var expectedSerializer = new JsonSerializer(settings); 
+            
+            var factory = new SerializerFactory(settings);
+            var serializer = factory.CreateJsonSerializer();
+            
+            Assert.AreEqual(expectedSerializer.Encode(strct), serializer.Encode(strct));
+        }
+    }
+}

--- a/unity/PitayaExample/Assets/Tests/SerializerFactoryTest.cs.meta
+++ b/unity/PitayaExample/Assets/Tests/SerializerFactoryTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a14e6e2a7a3d47f99798dbd3fb5f79c1
+timeCreated: 1612565149


### PR DESCRIPTION
`JsonSerializer` is ignoring its `JsonSerializerSettings` when invoking `JsonConvert.SerializeObject()`.

I fixed that and also added a unit test to validate it.