### PR TITLE
feat: enabling defining certificates directory

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -197,7 +197,7 @@ namespace Pitaya
         
         public static void SetCertificatePath(string path)
         {
-            NativeSetCertificatePath(path, null);
+            NativeSetCertificatePath(null, path);
         }
 
         public static void Request(IntPtr client, string route, byte[] msg, uint reqtId, int timeout)

--- a/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
@@ -60,7 +60,13 @@ namespace Pitaya
                 else
                     PitayaBinding.SetCertificateName(certificateName);
 #else
-                PitayaBinding.SetCertificateName(certificateName);
+                // Get the attributes from the path/file
+                FileAttributes attr = File.GetAttributes(certificateName);
+                // Set the certificate path if Directory
+                if (attr.HasFlag(FileAtribbutes.Directory))
+                    PitayaBinding.SetCertificatePath(certificateName);
+                else
+                    PitayaBinding.SetCertificateName(certificateName);
 #endif
             }
         }

--- a/unity/PitayaExample/LibPitaya.nuspec
+++ b/unity/PitayaExample/LibPitaya.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>LibPitaya</id>
-    <version>3.1.0</version>
+    <version>3.1.0-alpha</version>
     <authors>guthyerrz</authors>
     <owners>guthyerrz</owners>
     <projectUrl>https://github.com/topfreegames/libpitaya</projectUrl>


### PR DESCRIPTION
Adding the possibility of using `certificateName` as a reference to a directory, where we can read more than one certificate.
This MR change the behavior of the call to the libPitaya OpenSSL function: https://github.com/topfreegames/libpitaya/blob/master/src/tr/uv/tr_uv_tls.c#L38. We want to use a directory containing multiple paths to have a smooth transition during certificates renewal. 

This takes advantage of the behavior of the `SSL_CTX_load_verify_locations` function, passing the CAPath instead of the CAFile: https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_load_verify_locations.html

> When looking up CA certificates, the OpenSSL library will first search the certificates in CAfile, then those in CApath. Certificate matching is done based on the subject name, the key identifier (if present), and the serial number as taken from the certificate to be verified. If these data do not match, the next certificate will be tried. If a first certificate matching the parameters is found, the verification process will be performed; no other certificates for the same parameters will be searched in case of failure.