### PR TITLE
Backport event manager crash fix to 3.x

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/EventManager.cs
+++ b/unity/PitayaExample/Assets/Pitaya/EventManager.cs
@@ -105,8 +105,9 @@ namespace Pitaya
         // ReSharper disable once UnusedParameter.Local
         private void Dispose(bool disposing)
         {
-			foreach (var callback in _errorCallBackMap)
-				callback.Value.Invoke(new PitayaError(PitayaConstants.PitayaInternalError, "pitaya exited"));
+            var errorCallBackMap = new Dictionary<uint, Action<PitayaError>>(_errorCallBackMap);
+                foreach (var callback in errorCallBackMap)
+                    callback.Value.Invoke(new PitayaError(PitayaConstants.PitayaInternalError, "pitaya exited"));
 
             _callBackMap.Clear();
             _eventMap.Clear();

--- a/unity/PitayaExample/LibPitaya.nuspec
+++ b/unity/PitayaExample/LibPitaya.nuspec
@@ -2,13 +2,13 @@
 <package>
   <metadata>
     <id>LibPitaya</id>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <authors>guthyerrz</authors>
     <owners>guthyerrz</owners>
     <projectUrl>https://github.com/topfreegames/libpitaya</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>C# client for the pitaya server</description>
-    <releaseNotes>Add assembly definition file for editor</releaseNotes>
+    <releaseNotes>Fix crash caused by modified collection during enumeration in EventManager Dispose</releaseNotes>
     <licenseUrl>https://github.com/topfreegames/libpitaya/blob/master/LICENSE</licenseUrl>
     <copyright>Copyright (c) 2018 TFG Co, NetEase Inc. and other pomelo contributors</copyright>
     <tags>pitaya libpitaya</tags>


### PR DESCRIPTION
Since the 4.x version does not support Unity 2018, we ported this fix from 4.x to 3.x as there were crash reports in games using pitaya.