### PR TITLE
Support custom log functions

### DIFF
--- a/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs
@@ -133,7 +133,7 @@ namespace Pitaya
 #endif
         }
 
-        private static void SetLogFunction(NativeLogFunction fn)
+        public static void SetLogFunction(NativeLogFunction fn)
         {
             int rc = NativeInitLogFunction(fn);
             if (rc != 0)
@@ -272,12 +272,13 @@ namespace Pitaya
 
             if (rc != PitayaConstants.PcRcOk)
             {
-                DLog(string.Format("request - failed to perform request {0}", RcToStr(rc)));
+                var rcStr = RcToStr(rc)
+                DLog(string.Format("request - failed to perform request {0}", rcStr));
 
                 WeakReference reference;
                 if (!Listeners.TryGetValue(client, out reference) || !reference.IsAlive) return;
                 var listener = reference.Target as IPitayaListener;
-                if (listener != null) listener.OnRequestError(reqtId, new PitayaError(PitayaConstants.PitayaInternalError, "Failed to send request"));
+                if (listener != null) listener.OnRequestError(reqtId, new PitayaError(rcStr, "Failed to send request"));
             }
         }
 

--- a/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
+++ b/unity/PitayaExample/Assets/Pitaya/PitayaClient.cs
@@ -61,6 +61,11 @@ namespace Pitaya
             StaticPitayaBinding.SetLogLevel(level);
         }
 
+        public static void SetLogFunction(NativeLogFunction fn)
+        {
+            StaticPitayaBinding.SetLogFunction(fn);
+        }
+
         public int Quality
         {
             get { return _binding.Quality(_client); }


### PR DESCRIPTION
Changed the access modifier of SetLogFunction to public in order to allow set custom log functions to the lib.

Changed the hard coded error by the actual error returned by the NativeBinaryRequest method