### PR TITLE
Move event triggers to after the connection timer is reset

### DIFF
--- a/src/tr/uv/tr_uv_tcp_aux.c
+++ b/src/tr/uv/tr_uv_tcp_aux.c
@@ -957,8 +957,8 @@ void tcp__on_data_recieved(tr_uv_tcp_transport_t* tt, const char* data, size_t l
 void tcp__on_kick_recieved(tr_uv_tcp_transport_t* tt)
 {
     pc_lib_log(PC_LOG_INFO, "tcp__on_kick_recieved - kicked by server");
-    pc_trans_fire_event(tt->client, PC_EV_KICKED_BY_SERVER, NULL, NULL);
     tt->reset_fn(tt);
+    pc_trans_fire_event(tt->client, PC_EV_KICKED_BY_SERVER, NULL, NULL);
 }
 
 void tcp__send_handshake(tr_uv_tcp_transport_t* tt)
@@ -1073,8 +1073,8 @@ void tcp__on_handshake_resp(tr_uv_tcp_transport_t* tt, const char* data, size_t 
 
     if (!res) {
         pc_lib_log(PC_LOG_ERROR, "tcp__on_handshake_resp - handshake resp is not valid json");
-        pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "Handshake Error", NULL);
         tt->reset_fn(tt);
+        pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "Handshake Error", NULL);
         return ;
     }
 
@@ -1082,9 +1082,9 @@ void tcp__on_handshake_resp(tr_uv_tcp_transport_t* tt, const char* data, size_t 
 
     if (!tmp || tmp->type != pc_JSON_Number || (code = tmp->valueint) != PC_HANDSHAKE_OK) {
         pc_lib_log(PC_LOG_ERROR, "tcp__on_handshake_resp - handshake fail, code: %d", code);
+        tt->reset_fn(tt);
         pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "Handshake Error", NULL);
         pc_JSON_Delete(res);
-        tt->reset_fn(tt);
         return ;
     }
 
@@ -1092,9 +1092,9 @@ void tcp__on_handshake_resp(tr_uv_tcp_transport_t* tt, const char* data, size_t 
     sys = pc_JSON_GetObjectItem(res, "sys");
     if (!sys) {
         pc_lib_log(PC_LOG_ERROR, "tcp__on_handshake_resp - handshake fail, no sys field");
+        tt->reset_fn(tt);
         pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "Handshake Error", NULL);
         pc_JSON_Delete(res);
-        tt->reset_fn(tt);
         return ;
     }
 

--- a/src/tr/uv/tr_uv_tls_aux.c
+++ b/src/tr/uv/tr_uv_tls_aux.c
@@ -208,9 +208,10 @@ static void tls__emit_error_event(tr_uv_tls_transport_t* tls)
 
     if (!tls->is_handshake_completed) {
         /* won't reconnect if tls handshake failed */
-        pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "TLS Handshake Error", NULL);
         tt->reset_fn(tt);
+        pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "TLS Handshake Error", NULL);
     } else {
+        tt->reset_fn(tt);
         pc_trans_fire_event(tt->client, PC_EV_UNEXPECTED_DISCONNECT, "TLS Error", NULL);
         tt->reconn_fn(tt);
     }
@@ -273,8 +274,8 @@ static void tls__write_to_bio(tr_uv_tls_transport_t* tls)
             if (!tls->is_handshake_completed) {
                 if (!tls__public_key_pinned(tls)) {
                     pc_lib_log(PC_LOG_ERROR, "Public key is not pinned.");
-                    pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "Public key from server is not pinned.", NULL);
                     tt->reset_fn(tt);
+                    pc_trans_fire_event(tt->client, PC_EV_CONNECT_FAILED, "Public key from server is not pinned.", NULL);
                     return;
                 }
 


### PR DESCRIPTION
Hey there,

We’re seeing a bad behaviour and we need your help to pinpoint the issue. The symptom is the following:

1. The app goes to background and we force a disconnection on a connected pitaya instance.
2. The app returns to foreground and we receive the disconnection callback
2. We try to call connect again, but it fails with “connect timeout”

Notes: 
* We have connectivity at all times
* The flow surprisingly works if we delay the “connect” asynchronously for 50ms

All of this leads me to believe that the issue might be related to a bad clean up/reset of the connection timer, and investigating the code, I found several places where we actually trigger the disconnection events before we reset it (see the changes in this PR). So I wonder if it might get triggered and interrupt the newly started connection before being reset.

Also, I see that when initializing the timer, we don't reset its state [here](https://github.com/topfreegames/libpitaya/blob/f869c882860e5d54c7128feff132d191c4feaa84/src/tr/uv/tr_uv_tcp_i.c#LL157C2-L157C2), but I couldn't fully track if this is called when we initialize the connection flow. I think it's called only during the static initialization flow, so this might not be related to the issue 🤔.