### PR TITLE
fix(macos): load zlib

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,6 +49,56 @@ jobs:
       - name: Build
         run: make build-mac-xcode
 
+      - name: Check rpath for system library fallback
+        run: |
+          BUNDLE="_builds/mac-xcode/Release/libpitaya-mac.bundle"
+          
+          # Display bundle dependencies
+          echo "=== Bundle dependencies ==="
+          otool -L "$BUNDLE" | head -10
+          echo ""
+          
+          # Display rpath entries
+          echo "=== Rpath entries ==="
+          otool -l "$BUNDLE" | grep -A2 "LC_RPATH" || echo "WARNING: No rpath entries found"
+          echo ""
+          
+          # Check if /usr/lib is in rpath
+          if ! otool -l "$BUNDLE" | grep -q "path /usr/lib"; then
+            echo "❌ ERROR: /usr/lib is NOT in rpath!"
+            echo "The bundle will fail to load on target machines."
+            echo ""
+            echo "To fix this, add to CMakeLists.txt:"
+            echo "  if(APPLE AND BUILD_MACOS_BUNDLE)"
+            echo "    set_target_properties(pitaya PROPERTIES"
+            echo "      BUILD_RPATH \"/usr/lib\""
+            echo "      INSTALL_RPATH \"/usr/lib\")"
+            echo "  endif()"
+            exit 1
+          fi
+          
+          echo "✅ /usr/lib is in rpath"
+          echo ""
+          
+          # Test if bundle can be loaded
+          echo "=== Testing bundle loading ==="
+          cat > /tmp/test_bundle.c << 'EOF'
+          #include <dlfcn.h>
+          #include <stdio.h>
+          int main(int argc, char **argv) {
+              void* handle = dlopen(argv[1], RTLD_NOW);
+              if (!handle) {
+                  printf("ERROR: %s\n", dlerror());
+                  return 1;
+              }
+              printf("SUCCESS: Bundle loads correctly\n");
+              dlclose(handle);
+              return 0;
+          }
+          EOF
+          cc -o /tmp/test_bundle /tmp/test_bundle.c
+          /tmp/test_bundle "$BUNDLE"
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning]
 (https://semver.org/spec/v2.0.0.html).
 
+## 4.6.5 - 2025-12-02
+### Fixed
+- Fixed `DllNotFoundException` on Unity Editor running on Mac OS due to missing `zlib` dependency
+
 ## 4.6.4 - 2025-11-26
 ### Changed
 - Add OpenSSL-TFG as dependency for iOS builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,18 @@ elseif(ANDROID)
         ssl
         crypto
         ${ANDROID_LOG_LIB})
+elseif(APPLE AND BUILD_MACOS_BUNDLE)
+   # Add /usr/lib to rpath so @rpath/libz.1.dylib can be found
+    set_target_properties(pitaya PROPERTIES
+        BUILD_RPATH "/usr/lib"
+        INSTALL_RPATH "/usr/lib"
+    )
+    target_link_libraries(pitaya
+      PRIVATE
+        zlib
+        uv_a
+        ssl
+        crypto)
 else()
     target_link_libraries(pitaya
       PRIVATE


### PR DESCRIPTION
Latest version of Pitaya fails on Unity Editor running on Mac OS

```
DllNotFoundException: libpitaya-mac assembly:<unknown assembly> type:<unknown type> member:(null)
Pitaya.StaticPitayaBinding.SetLogFunction (NativeLogFunction fn) (at <b477b557aa9a4327aaf49e545dc992f2>:0)
Pitaya.StaticPitayaBinding..cctor () (at <b477b557aa9a4327aaf49e545dc992f2>:0)
Rethrow as TypeInitializationException: The type initializer for 'Pitaya.StaticPitayaBinding' threw an exception.
Pitaya.PitayaBinding.set_QueueDispatcher (Pitaya.IPitayaQueueDispatcher value) (at <b477b557aa9a4327aaf49e545dc992f2>:0)
```

The root cause is a failure in loading zlib. The fix add a fallback path to `/usr/lib` in order to find the shared lib `libz.1.dylib`