### PR TITLE
ci: build and package Linux arm64 (aarch64) native library

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -165,6 +165,24 @@ jobs:
           name: libpitaya_linux
           path: _builds/linux/libpitaya-linux.so
 
+  build-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Build linux image with target glibc version (arm64)
+        run: docker build -t builder .
+
+      - name: Build linux arm64 lib from version supported in Dockerfile
+        run: docker run --rm --workdir /project --env MSBUILD --env CONTENTS_DIR --env UNITY_PATH -v ${PWD}:/project builder:latest /bin/bash -c "make build-linux"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libpitaya_linux_arm64
+          path: _builds/linux/libpitaya-linux.so
+
   build-dll:
     name: Build DLLs
     runs-on: ubuntu-latest
@@ -200,6 +218,7 @@ jobs:
       - build-android
       - build-android-64
       - build-linux
+      - build-linux-arm64
       - build-dll
     steps:
       - name: Checkout repo

--- a/package.sh
+++ b/package.sh
@@ -24,6 +24,7 @@ cp -r ./unity/PitayaExample/Assets/Pitaya/Editor package
 cp libpitaya_android64/* package/PitayaNativeLibraries/Android/arm64/
 cp libpitaya_android/* package/PitayaNativeLibraries/Android/armv7/
 cp libpitaya_linux/* package/PitayaNativeLibraries/Linux/
+cp libpitaya_linux_arm64/* package/PitayaNativeLibraries/Linux/arm64/
 cp libpitaya_mac/* package/PitayaNativeLibraries/Mac/
 find libpitaya_ios -type f -exec cp "{}" package/PitayaNativeLibraries/iOS/device/ \;
 find libpitaya_ios-simulator -type f -exec cp "{}" package/PitayaNativeLibraries/iOS/simulator/ \;

--- a/package/PitayaNativeLibraries/Linux/arm64.meta
+++ b/package/PitayaNativeLibraries/Linux/arm64.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32b7ac4c47c04c348ea200daaf47900b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/PitayaNativeLibraries/Linux/arm64/libpitaya-linux.so.meta
+++ b/package/PitayaNativeLibraries/Linux/arm64/libpitaya-linux.so.meta
@@ -1,0 +1,31 @@
+fileFormatVersion: 2
+guid: 94ea14badcb4d412c91373570435dc66
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 3
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+    Android:
+      enabled: 0
+      settings:
+        Is16KbAligned: true
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+    Linux64:
+      enabled: 1
+      settings:
+        CPU: ARM64
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What
Adds **Linux arm64 (aarch64)** to the build/release pipeline so `com.wildlifestudios.nuget.libpitaya` ships an arm64 native lib — enabling Unity dedicated servers / game rooms to run on Linux **arm64 (Graviton)** hosts.

## Changes (purely additive)
- **`.github/workflows/build-and-release.yaml`**: new `build-linux-arm64` job (runs on `ubuntu-24.04-arm`, uses the **same `Dockerfile`** so the target glibc matches the x86_64 build), uploading `libpitaya_linux_arm64`. Added to the `package` job `needs`.
- **`package.sh`**: copies the arm64 artifact into `PitayaNativeLibraries/Linux/arm64/`.
- **`package/PitayaNativeLibraries/Linux/arm64/libpitaya-linux.so.meta`** (new): plugin meta targeting **Standalone Linux64 / CPU ARM64**, plus the folder `.meta`.
- The existing x86_64 lib and its meta (Linux64 CPU `x86_64`) are **unchanged** → x86_64 builds are unaffected; Unity 6 selects the right lib per build architecture (confirmed the importer accepts `CPU=ARM64` for Standalone Linux64).

## Validation
An arm64 `libpitaya-linux.so` built this way (native aarch64, glibc-matched) was verified with `dlopen` + `LD_BIND_NOW` inside the target arm64 game image — loads with all symbols resolved. NEEDED: `libz.so.1, libm, libc` (OpenSSL linked statically), a subset of the x86_64 lib.

## Note
Same `DllImport` name in a separate `Linux/arm64/` folder (mirrors the existing Android arm64/armv7 layout) so only one lib is active per build arch.