### PR TITLE
fix(ci): rebuild vendored OpenSSL for aarch64 (unblock 4.7.0 arm64 publish)

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -175,7 +175,21 @@ jobs:
         run: docker build -t builder .
 
       - name: Build linux arm64 lib from version supported in Dockerfile
-        run: docker run --rm --workdir /project --env MSBUILD --env CONTENTS_DIR --env UNITY_PATH -v ${PWD}:/project builder:latest /bin/bash -c "make build-linux"
+        # The vendored deps/openssl/linux is a precompiled x86_64 OpenSSL, so on
+        # arm64 the final link fails ("libssl.a ... file in wrong format"). Rebuild
+        # OpenSSL 1.1.1q for linux-aarch64 into deps/openssl/linux before building.
+        run: |
+          docker run --rm --workdir /project --env MSBUILD --env CONTENTS_DIR --env UNITY_PATH -v ${PWD}:/project builder:latest /bin/bash -c '
+            set -e
+            apt-get update && apt-get install -y perl
+            tar xzf deps/openssl-1.1.1q.tar.gz -C /tmp
+            cd /tmp/openssl-1.1.1q
+            ./Configure linux-aarch64 --prefix=/project/deps/openssl/linux
+            make -j"$(nproc)"
+            make install_sw
+            cd /project
+            make build-linux
+          '
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
The **4.7.0 release failed** — `build-linux-arm64` (added in #105) failed at `make build-linux`:
```
/usr/bin/ld: ../../deps/openssl/linux/lib/libssl.a(methods.o): Relocations in generic ELF (EM: 62)
../../deps/openssl/linux/lib/libssl.a: error adding symbols: file in wrong format
```
`deps/openssl/linux` is a **precompiled x86_64 OpenSSL**, so the arm64 link fails. Because that job is in the `package` job's `needs`, the failure **blocked publish** → 4.7.0 was tagged but never pushed to Artifactory (latest there is still 4.6.5).

## Fix
In `build-linux-arm64`, rebuild the vendored **OpenSSL 1.1.1q for `linux-aarch64`** into `deps/openssl/linux` (installing `perl` for OpenSSL's `Configure`) before `make build-linux`. Same image/flow otherwise.

## Validation
Ran the exact recipe in the same `ubuntu:20.04` arm64 builder (`podman`, native aarch64): `make build-linux` completes with **0 errors** and produces an **aarch64** `libpitaya-linux.so` (verified ELF machine = 0xB7). The earlier prebuilt arm64 `.so` from this recipe also `dlopen`s inside the target game image.

After merge, please cut a new tag so the release/publish runs (4.7.0 never published, so 4.7.0 or 4.7.1 both work).